### PR TITLE
FIX #7 Whitespace bug when generating LDAP configs

### DIFF
--- a/install/etc/cont-init.d/10-nginx
+++ b/install/etc/cont-init.d/10-nginx
@@ -321,7 +321,7 @@ if var_true "$NGINX_ENABLE_APPLICATION_CONFIGURATION"; then
         satisfy all;
       }
 EOF
-    sed -i '/ server {/a\ \ \  auth_ldap '${NGINX_AUTHENTICATION_TITLE}'; auth_ldap_servers ldapserver;' /etc/nginx/conf.d/*.conf
+    sed -i '/ server {/a\ \ \  auth_ldap "'"${NGINX_AUTHENTICATION_TITLE}"'";\n\ \ \  auth_ldap_servers ldapserver;' /etc/nginx/conf.d/*.conf
     sed -i "\#include /etc/nginx/conf.d/#i\ \ \ \ include /etc/nginx/nginx.conf.d/authentication/ldap_configuration;" /etc/nginx/nginx.conf
     ;;
   "LLNG")


### PR DESCRIPTION
Hopefully this fixes #7, the white-space problem, as well as adding the 'nice to have' line break before the next config statement.