### PR TITLE
Add matching delimiter for sed for LDAP auth

### DIFF
--- a/install/assets/functions/10-nginx
+++ b/install/assets/functions/10-nginx
@@ -33,7 +33,7 @@ nginx_configure_authentication() {
           satisfy all;
         }
 EOF
-            sed -i "\|include /etc/nginx/sites.enabled#i\ \ \ \ include /etc/nginx/snippets/authentication/ldap_configuration;" /etc/nginx/nginx.conf
+            sed -i "\|include /etc/nginx/sites.enabled| i\ \ \ \ include /etc/nginx/snippets/authentication/ldap_configuration;" /etc/nginx/nginx.conf
         ;;
         "llng" )
             print_notice "Setting LLNG Authentication"


### PR DESCRIPTION
Using the fusiondirectory image with `NGINX_AUTHENTICATION_TYPE=LDAP`, nginx will not start and the docker-compose logs show:

fusiondirectory-app  | sed: unmatched '|'

Line 36 in the functions/10-nginx uses two different delimiters, so this commit just unifies them into a pipe.

https://github.com/tiredofit/docker-nginx/blob/349172d19564cd57d97b272c31d9597b963781ec/install/assets/functions/10-nginx#L36