### PR TITLE
Fix llng_auth_request config empty params

### DIFF
--- a/install/assets/functions/10-nginx
+++ b/install/assets/functions/10-nginx
@@ -58,7 +58,7 @@ EOF
             update_template /etc/nginx/snippets/authentication/llng_location_block NGINX_AUTHENTICATION_LLNG_HANDLER_PORT
 
             if [ ! -f "/etc/cont-init.d/20-php-fpm" ]; then
-                header_num=$(printenv | sort | grep -c '\NGINX_AUTHENTICATION_LLNG_ATTRIBUTE.*')
+                header_num=$(printenv | sort | grep -c '^NGINX_AUTHENTICATION_LLNG_ATTRIBUTE.*')
                 for ((i = 1; i <= header_num; i++)); do
                     headers=NGINX_AUTHENTICATION_LLNG_ATTRIBUTE${i}
                     IFS=',' read -r -a array <<<"${!headers}"


### PR DESCRIPTION
Hi tireofit,

In starting up a latest docker-nginx with LLNG auth today, the docker-compose logs showed 

```
  nginx-app  | 2023-02-03.20:23:57 [NOTICE] ** [nginx] Setting LLNG Authentication                                                                                                              
  nginx-app  | grep: warning: stray \ before N                                                                                                                                                  
  nginx-app  | 2023-02-03.20:23:57 [NOTICE] ** [nginx] Updating Nginx to support recieving attribute from LLNG: 'AUTH_USER'                                                                     
  nginx-app  | 2023-02-03.20:23:57 [NOTICE] ** [nginx] Updating Nginx to support recieving attribute from LLNG: 'GROUPS'                                                                        
  nginx-app  | 2023-02-03.20:23:57 [NOTICE] ** [nginx] Updating Nginx to support recieving attribute from LLNG: ''                                                                              
  nginx-app  | 2023-02-03.20:23:57 [NOTICE] ** [nginx] Updating Nginx to support recieving attribute from LLNG: ''                                                                              
  nginx-app  | 2023-02-03.20:23:57 [STARTING] ** [nginx] [1] Starting nginx 1.23.3                                                                                                              
  nginx-app  | nginx: [emerg] invalid variable name "$" in /etc/nginx/snippets/authentication/llng_auth_request:11                                                                              
  nginx-app  | 2023-02-03.20:23:57 [STARTING] ** [monitoring] [1] Starting Zabbix Agent (modern) 6.2.6                                                                                          
  nginx-app  | 2023-02-03.20:23:57 [STARTING] ** [scheduling] [1] Starting cron                                                                                                                 
  nginx-app  | 2023-02-03.20:23:58 [STARTING] ** [nginx] [2] Starting nginx 1.23.3                                                                                                              
  nginx-app  | nginx: [emerg] invalid variable name "$" in /etc/nginx/snippets/authentication/llng_auth_request:11                                                                              
  nginx-app  | 2023-02-03.20:23:59 [STARTING] ** [nginx] [3] Starting nginx 1.23.3                                                                                                              
  nginx-app  | nginx: [emerg] invalid variable name "$" in /etc/nginx/snippets/authentication/llng_auth_request:11
``` 
The invalid variable name issue was caused by a second set of params being appended to the bottom of the file. Inside the container, the file looked like: 

```
        ### Start LemonLDAP:NG Authentication
        set $original_uri $uri$is_args$args;
        auth_request /lmauth;
        auth_request_set $lmremote_user $upstream_http_lm_remote_user;
        auth_request_set $lmlocation $upstream_http_location;
        auth_request_set $cookie_value $upstream_http_set_cookie;
        add_header Set-Cookie $cookie_value;
        error_page 401 $lmlocation;
auth_request_set $mail $upstream_http_mail;
auth_request_set $groups $upstream_http_groups;
auth_request_set $ $;
auth_request_set $ $;
```

I started up the container with debug mode and found that the `for` loop [here](https://github.com/tiredofit/docker-nginx/blob/main/install/assets/functions/10-nginx#L62) was actually running 4 times, not the expected 2 times. In other words, `header_num` was actually 4 and was appending the empty lines after it ran out of populated/set `NGINX_AUTHENTICATION_LLNG_ATTRIBUTE`* env vars.

I added `printenv | sort > /tmp/dump-printenv` right after the line where you `printenv`, built an image, ran it, and found that the `printenv` also prints/includes the entire `/install/assets/functions/10-nginx` file as well as the env vars available within the container on startup. Weird. But that explains why the `for` loop ran 4 times instead of 2. On startup, the `header_num` also counts the two mentions of `NGINX_AUTHENTICATION_LLNG_ATTRIBUTE` in the `/install/assets/functions/10-nginx` file, see [1](https://github.com/tiredofit/docker-nginx/blob/main/install/assets/functions/10-nginx#L61) [2](https://github.com/tiredofit/docker-nginx/blob/main/install/assets/functions/10-nginx#L63). I resolved this by changing the grep statement to only look for lines beginning with `NGINX_AUTHENTICATION_LLNG_ATTRIBUTE`.

This pull request has my earlier commits, which were wrong, but my latest commit reverts those changes and instead changes one character from your repo: `\` --> `^`

This solves the issue, but might break again if `/install/assets/functions/10-nginx` file ever had a line that started with `NGINX_AUTHENTICATION_LLNG_ATTRIBUTE`. I think that would be unlikely. What do you think?